### PR TITLE
Update deployment pipeline for backend

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -72,10 +72,19 @@ jobs:
       - name: Remove old images
         run: docker image prune -af
 
-      # Run Prisma migrations on RDS
+      # Run Prisma migrations (reset or deploy depending on secret)
       - name: Run Prisma migrations
         run: |
-          docker run --rm \
-            -e DATABASE_URL=${{ secrets.DATABASE_URL_PROD }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{needs.build-and-push-image.outputs.image-tag}} \
-            npx prisma migrate deploy
+          if [ "${{ secrets.RESET_DB }}" = "true" ]; then
+            echo "⚠️ RESETTING DATABASE..."
+            docker run --rm \
+              -e DATABASE_URL=${{ secrets.DATABASE_URL_PROD }} \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{needs.build-and-push-image.outputs.image-tag}} \
+              npx prisma migrate reset --force --skip-seed
+          else
+            echo "✅ Applying safe migrations..."
+            docker run --rm \
+              -e DATABASE_URL=${{ secrets.DATABASE_URL_PROD }} \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{needs.build-and-push-image.outputs.image-tag}} \
+              npx prisma migrate deploy
+          fi


### PR DESCRIPTION
Fixed prisma migrations, to reset schema or deploy new modification depending on the gihub secret RESET_DB (for now, it is set to true, then in production it will be set to false)

## Linked issue

Resolves: #109 

## Summary
In dev, we will run migrate reset to migrate schema, while in production we will run migrate deploy (to only apply new chages). This will be automatic by checking a GitHub secret (e.g. RESET_DB) that we set to "true" when you want a reset (only during developement), and we can set to false when we need to keep our data and changes on the tables won't be problematic.