### PR TITLE
Feature/frontend/paint tool

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "format": "prettier 'src/**/*.{js,ts,tsx,jsx,mjs,cjs,json}' --write"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/frontend/src/app/api/auth/route.ts
+++ b/frontend/src/app/api/auth/route.ts
@@ -1,27 +1,30 @@
-import { NextResponse } from 'next/server';
+import { NextResponse } from "next/server";
 
 export async function POST(req: Request) {
-    const body = await req.json();
-    const { action, email, password, confirmPassword } = body;
+  const body = await req.json();
+  const { action, email, password, confirmPassword } = body;
 
-    if (!action || !email || !password) {
-        return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+  if (!action || !email || !password) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  }
+
+  if (action === "login") {
+    // Dummy login logic (replace with real auth later)
+    console.log("Logging in user:", email);
+    return NextResponse.json({ message: "User logged in (stub)" });
+  }
+
+  if (action === "register") {
+    if (password !== confirmPassword) {
+      return NextResponse.json(
+        { error: "Passwords do not match" },
+        { status: 400 },
+      );
     }
+    // Dummy registration logic (replace with real DB call)
+    console.log("Registering user:", email);
+    return NextResponse.json({ message: "User registered (stub)" });
+  }
 
-    if (action === 'login') {
-        // Dummy login logic (replace with real auth later)
-        console.log('Logging in user:', email);
-        return NextResponse.json({ message: 'User logged in (stub)' });
-    }
-
-    if (action === 'register') {
-        if (password !== confirmPassword) {
-            return NextResponse.json({ error: 'Passwords do not match' }, { status: 400 });
-        }
-        // Dummy registration logic (replace with real DB call)
-        console.log('Registering user:', email);
-        return NextResponse.json({ message: 'User registered (stub)' });
-    }
-
-    return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
+  return NextResponse.json({ error: "Invalid action" }, { status: 400 });
 }

--- a/frontend/src/app/editor/page.tsx
+++ b/frontend/src/app/editor/page.tsx
@@ -2,7 +2,7 @@
 
 import Konva from "konva";
 import dynamic from "next/dynamic";
-import React, { useState, useEffect, useCallback, useRef, } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { LoadImageButton } from "@/components/editor/loadImageButton";
 
 import { MOVE_TOOL } from "@/components/editor/tools/move";
@@ -22,7 +22,11 @@ import {
 import { useUndoRedo } from "@/components/editor/undoRedo";
 import { TOOLS, TOOLS_INITIAL_STATE } from "@/models/editor/utils/tools";
 
-import { EditorContext, CanvasState, EventHandlers } from "@/components/editor/editorContext";
+import {
+  EditorContext,
+  CanvasState,
+  EventHandlers,
+} from "@/components/editor/editorContext";
 
 const Canvas = dynamic(() => import("@/components/editor/canvas"), {
   ssr: false,
@@ -131,38 +135,44 @@ export default function EditorPage() {
     [findLayer, setLayers, setVirtualLayers],
   );
 
-  const editSelectedLayers = (callback: LayerUpdateCallback, virtual: boolean = false) => {
+  const editSelectedLayers = (
+    callback: LayerUpdateCallback,
+    virtual: boolean = false,
+  ) => {
     const fun = virtual ? setVirtualLayers : setLayers;
-    fun(prev => {
-      return prev.map(layer => {
+    fun((prev) => {
+      return prev.map((layer) => {
         if (!layer.isSelected) {
           return layer;
         }
         return callback(layer);
-      })
-    })
-  }
+      });
+    });
+  };
 
   return (
     <main className="bg-gray-900 min-h-screen">
-      <EditorContext value={{
-        isHoldingPrimary,
-        isTransforming,
+      <EditorContext
+        value={{
+          isHoldingPrimary,
+          isTransforming,
 
-        setVirtualLayers,
-        updateLayer,
-        editSelectedLayers,
-        commitVirtualLayers,
+          layers,
+          setVirtualLayers,
+          updateLayer,
+          editSelectedLayers,
+          commitVirtualLayers,
 
-        getCanvasPointerPosition,
+          getCanvasPointerPosition,
 
-        canvasState,
-        setCanvasState,
-        stageRef,
+          canvasState,
+          setCanvasState,
+          stageRef,
 
-        toolEventHandlers,
-        setToolEventHandlers,
-      }}>
+          toolEventHandlers,
+          setToolEventHandlers,
+        }}
+      >
         <div className="flex flex-row">
           <div className="flex-1">
             <div className="flex flex-col p-4">

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,91 +1,99 @@
-'use client';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+"use client";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 export default function LoginPage() {
-    const router = useRouter();
-    const [formData, setFormData] = useState({ email: '', password: '' });
+  const router = useRouter();
+  const [formData, setFormData] = useState({ email: "", password: "" });
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setFormData({ ...formData, [e.target.name]: e.target.value });
-    };
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        const res = await fetch('/api/auth/login', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(formData),
-        });
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch("/api/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(formData),
+    });
 
-        const data = await res.json();
-        console.log(data); // Handle redirect or error
-    };
+    const data = await res.json();
+    console.log(data); // Handle redirect or error
+  };
 
-    return (
-        <div className="min-h-screen flex items-center justify-center p-6">
-            <div className="w-full max-w-md">
-                <h2 className="text-2xl font-bold mb-6 text-center">Login</h2>
-                <form onSubmit={handleSubmit} className="space-y-4">
-                    <input
-                        type="email"
-                        name="email"
-                        value={formData.email}
-                        onChange={handleChange}
-                        placeholder="Email"
-                        className="w-full px-4 py-2 border rounded"
-                        required
-                    />
-                    <input
-                        type="password"
-                        name="password"
-                        value={formData.password}
-                        onChange={handleChange}
-                        placeholder="Password"
-                        className="w-full px-4 py-2 border rounded"
-                        required
-                    />
-                    <button
-                        type="submit"
-                        className="w-full bg-violet-500 text-white py-2 rounded-md hover:bg-violet-800"
-                    >
-                        Login
-                    </button>
-                </form>
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6">
+      <div className="w-full max-w-md">
+        <h2 className="text-2xl font-bold mb-6 text-center">Login</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="email"
+            name="email"
+            value={formData.email}
+            onChange={handleChange}
+            placeholder="Email"
+            className="w-full px-4 py-2 border rounded"
+            required
+          />
+          <input
+            type="password"
+            name="password"
+            value={formData.password}
+            onChange={handleChange}
+            placeholder="Password"
+            className="w-full px-4 py-2 border rounded"
+            required
+          />
+          <button
+            type="submit"
+            className="w-full bg-violet-500 text-white py-2 rounded-md hover:bg-violet-800"
+          >
+            Login
+          </button>
+        </form>
 
-                <div className="mt-4 text-center text-sm">
-                    <button
-                        onClick={() => router.push('/pwrecovery')}
-                        className="text-blue-600 hover:underline block"
-                    >
-                        Forgot Password?
-                    </button>
-                </div>
-
-                <div className="my-6 flex items-center gap-2">
-                    <div className="flex-grow border-t" />
-                    <span className="text-xs text-gray-500">or login using</span>
-                    <div className="flex-grow border-t" />
-                </div>
-
-                <div className="grid grid-cols-2 gap-3 mb-4">
-                    <button className="w-full py-2 border rounded hover:bg-gray-100">Google</button>
-                    <button className="w-full py-2 border rounded hover:bg-gray-100">LinkedIn</button>
-                    <button className="w-full py-2 border rounded hover:bg-gray-100">X</button>
-                    <button className="w-full py-2 border rounded hover:bg-gray-100">Microsoft</button>
-                </div>
-
-                <div className="text-center text-sm">
-                    --- or ---
-                    <br />
-                    <button
-                        onClick={() => router.push('/register')}
-                        className="text-blue-600 hover:underline"
-                    >
-                        Register using Email
-                    </button>
-                </div>
-            </div>
+        <div className="mt-4 text-center text-sm">
+          <button
+            onClick={() => router.push("/pwrecovery")}
+            className="text-blue-600 hover:underline block"
+          >
+            Forgot Password?
+          </button>
         </div>
-    );
+
+        <div className="my-6 flex items-center gap-2">
+          <div className="flex-grow border-t" />
+          <span className="text-xs text-gray-500">or login using</span>
+          <div className="flex-grow border-t" />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 mb-4">
+          <button className="w-full py-2 border rounded hover:bg-gray-100">
+            Google
+          </button>
+          <button className="w-full py-2 border rounded hover:bg-gray-100">
+            LinkedIn
+          </button>
+          <button className="w-full py-2 border rounded hover:bg-gray-100">
+            X
+          </button>
+          <button className="w-full py-2 border rounded hover:bg-gray-100">
+            Microsoft
+          </button>
+        </div>
+
+        <div className="text-center text-sm">
+          --- or ---
+          <br />
+          <button
+            onClick={() => router.push("/register")}
+            className="text-blue-600 hover:underline"
+          >
+            Register using Email
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/app/pwrecovery/page.tsx
+++ b/frontend/src/app/pwrecovery/page.tsx
@@ -1,55 +1,57 @@
-'use client';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+"use client";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 export default function PasswordRecoveryPage() {
-    const router = useRouter();
-    const [email, setEmail] = useState('');
+  const router = useRouter();
+  const [email, setEmail] = useState("");
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        const res = await fetch('/api/auth/forgot-password', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ email }),
-        });
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch("/api/auth/forgot-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
 
-        const data = await res.json();
-        console.log(data); // Handle email sent / error
-    };
+    const data = await res.json();
+    console.log(data); // Handle email sent / error
+  };
 
-    return (
-        <div className="min-h-screen flex items-center justify-center p-6">
-            <div className="w-full max-w-md">
-                <h2 className="text-2xl font-bold mb-6 text-center">Recover Password</h2>
-                <form onSubmit={handleSubmit} className="space-y-4">
-                    <input
-                        type="email"
-                        name="email"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                        placeholder="Enter your email"
-                        className="w-full px-4 py-2 border rounded"
-                        required
-                    />
-                    <button
-                        type="submit"
-                        className="w-full bg-violet-500 text-white py-2 rounded-md hover:bg-violet-800"
-                    >
-                        Send Recovery Email
-                    </button>
-                </form>
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6">
+      <div className="w-full max-w-md">
+        <h2 className="text-2xl font-bold mb-6 text-center">
+          Recover Password
+        </h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="email"
+            name="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Enter your email"
+            className="w-full px-4 py-2 border rounded"
+            required
+          />
+          <button
+            type="submit"
+            className="w-full bg-violet-500 text-white py-2 rounded-md hover:bg-violet-800"
+          >
+            Send Recovery Email
+          </button>
+        </form>
 
-                <p className="mt-4 text-center text-sm">
-                    Remembered your password?{' '}
-                    <button
-                        onClick={() => router.push('/login')}
-                        className="text-blue-600 hover:underline"
-                    >
-                        Back to Login
-                    </button>
-                </p>
-            </div>
-        </div>
-    );
+        <p className="mt-4 text-center text-sm">
+          Remembered your password?{" "}
+          <button
+            onClick={() => router.push("/login")}
+            className="text-blue-600 hover:underline"
+          >
+            Back to Login
+          </button>
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/editor/canvas.tsx
+++ b/frontend/src/components/editor/canvas.tsx
@@ -2,9 +2,17 @@
 
 "use client";
 
-import React, { useRef, useState, useCallback, createContext } from "react";
+import React, { useRef, useState } from "react";
 import { Stage, Layer as KonvaLayer, Rect } from "react-konva";
-import { CANVAS_DRAG_MOUSE_BUTTON, KonvaMouseEvent, KonvaScrollEvent, MOUSE_DOWN, MOUSE_MOVE, MOUSE_UP, PRIMARY_MOUSE_BUTTON } from "@/models/editor/utils/events";
+import {
+  CANVAS_DRAG_MOUSE_BUTTON,
+  KonvaMouseEvent,
+  KonvaScrollEvent,
+  MOUSE_DOWN,
+  MOUSE_MOVE,
+  MOUSE_UP,
+  PRIMARY_MOUSE_BUTTON,
+} from "@/models/editor/utils/events";
 import {
   Layer,
   LayerId,
@@ -12,8 +20,6 @@ import {
 } from "@/models/editor/layers/layer";
 import { LayerComponent } from "./layers/layer";
 import { Vector2d } from "konva/lib/types";
-import { TransformDiff } from "@/models/editor/layers/layerProps";
-import { v2Add, } from "@/models/editor/layers/layerUtils";
 import { useEditorContext } from "@/components/editor/editorContext";
 
 type CanvasProps = {
@@ -44,9 +50,14 @@ export const Canvas = ({
       y: 0,
     });
 
-  const isTransforming = useRef(false);
-
-  const { editSelectedLayers, getCanvasPointerPosition, canvasState, setCanvasState, stageRef, toolEventHandlers, isHoldingPrimary } = useEditorContext();
+  const {
+    getCanvasPointerPosition,
+    canvasState,
+    setCanvasState,
+    stageRef,
+    toolEventHandlers,
+    isHoldingPrimary,
+  } = useEditorContext();
 
   const handleMouseDown = (e: KonvaMouseEvent) => {
     e.evt.preventDefault();
@@ -99,7 +110,7 @@ export const Canvas = ({
       const handler = toolEventHandlers.current[MOUSE_UP];
       if (handler) {
         handler(e);
-        return
+        return;
       }
     }
   };

--- a/frontend/src/components/editor/editorContext.tsx
+++ b/frontend/src/components/editor/editorContext.tsx
@@ -11,7 +11,9 @@ export type CanvasState = {
   position: Vector2d;
 };
 
-export type EventHandlers = Partial<Record<EventType, (event?: KonvaMouseEvent) => void>>
+export type EventHandlers = Partial<
+  Record<EventType, (event?: KonvaMouseEvent) => void>
+>;
 
 // Define the complete context of the editor. This allows child components to edit
 // what is needed in the whole editor.
@@ -19,8 +21,16 @@ interface EditorContextType {
   isHoldingPrimary: React.RefObject<boolean>;
   isTransforming: React.RefObject<boolean>;
 
-  updateLayer: (id: LayerId, callback: LayerUpdateCallback, virtual?: boolean) => void;
-  editSelectedLayers: (callback: LayerUpdateCallback, virtual?: boolean) => void;
+  layers: Layer[];
+  updateLayer: (
+    id: LayerId,
+    callback: LayerUpdateCallback,
+    virtual?: boolean,
+  ) => void;
+  editSelectedLayers: (
+    callback: LayerUpdateCallback,
+    virtual?: boolean,
+  ) => void;
   commitVirtualLayers: () => void;
   setVirtualLayers: VirtualStateSetter<Layer[]>;
 
@@ -32,7 +42,7 @@ interface EditorContextType {
 
   toolEventHandlers: React.RefObject<EventHandlers>;
   setToolEventHandlers: (eventHandlers: EventHandlers) => void;
-};
+}
 
 export const EditorContext = createContext<EditorContextType | null>(null);
 
@@ -44,4 +54,4 @@ export const useEditorContext = () => {
   }
 
   return editorContext;
-}
+};

--- a/frontend/src/components/editor/editorContext.tsx
+++ b/frontend/src/components/editor/editorContext.tsx
@@ -1,0 +1,31 @@
+import { LayerUpdateCallback } from "@/models/editor/layers/layer";
+import { KonvaMouseEvent } from "@/models/editor/utils/events";
+import Konva from "konva";
+import { Vector2d } from "konva/lib/types";
+import { createContext, useContext } from "react";
+
+export type CanvasState = {
+  scale: number;
+  position: Vector2d;
+};
+
+interface EditorContextType {
+  editSelectedLayers: (callback: LayerUpdateCallback, virtual?: boolean) => void;
+  getCanvasPointerPosition: () => Vector2d;
+  handleLayerSelection: (e: KonvaMouseEvent) => void;
+  canvasState: CanvasState;
+  setCanvasState: React.Dispatch<React.SetStateAction<CanvasState>>;
+  stageRef: React.RefObject<Konva.Stage | null>;
+};
+
+export const EditorContext = createContext<EditorContextType | null>(null);
+
+export const useEditorContext = () => {
+  const editorContext = useContext(EditorContext);
+
+  if (!editorContext) {
+    throw new Error("Trying to use editor context before intitialization.");
+  }
+
+  return editorContext;
+}

--- a/frontend/src/components/editor/editorContext.tsx
+++ b/frontend/src/components/editor/editorContext.tsx
@@ -1,21 +1,37 @@
-import { LayerUpdateCallback } from "@/models/editor/layers/layer";
-import { KonvaMouseEvent } from "@/models/editor/utils/events";
+import { LayerId, LayerUpdateCallback } from "@/models/editor/layers/layer";
+import { KonvaMouseEvent, EventType } from "@/models/editor/utils/events";
 import Konva from "konva";
 import { Vector2d } from "konva/lib/types";
-import { createContext, useContext } from "react";
+import React, { createContext, useContext } from "react";
+import { Layer } from "@/models/editor/layers/layer";
+import { VirtualStateSetter } from "./undoRedo";
 
 export type CanvasState = {
   scale: number;
   position: Vector2d;
 };
 
+export type EventHandlers = Partial<Record<EventType, (event?: KonvaMouseEvent) => void>>
+
+// Define the complete context of the editor. This allows child components to edit
+// what is needed in the whole editor.
 interface EditorContextType {
+  isHoldingPrimary: React.RefObject<boolean>;
+  isTransforming: React.RefObject<boolean>;
+
+  updateLayer: (id: LayerId, callback: LayerUpdateCallback, virtual?: boolean) => void;
   editSelectedLayers: (callback: LayerUpdateCallback, virtual?: boolean) => void;
+  commitVirtualLayers: () => void;
+  setVirtualLayers: VirtualStateSetter<Layer[]>;
+
   getCanvasPointerPosition: () => Vector2d;
-  handleLayerSelection: (e: KonvaMouseEvent) => void;
+
   canvasState: CanvasState;
   setCanvasState: React.Dispatch<React.SetStateAction<CanvasState>>;
   stageRef: React.RefObject<Konva.Stage | null>;
+
+  toolEventHandlers: React.RefObject<EventHandlers>;
+  setToolEventHandlers: (eventHandlers: EventHandlers) => void;
 };
 
 export const EditorContext = createContext<EditorContextType | null>(null);

--- a/frontend/src/components/editor/layers/layer.tsx
+++ b/frontend/src/components/editor/layers/layer.tsx
@@ -31,14 +31,14 @@ export const LayerComponent = forwardRef<Konva.Group, LayerProps>(
     const transformerRef = useRef<Konva.Transformer>(null);
 
     const transformSelectedLayers = (diff: TransformDiff) => {
-      editSelectedLayers(layer => {
+      editSelectedLayers((layer) => {
         return {
           ...layer,
           scale: v2Add(layer.scale, diff.scale),
           position: v2Add(layer.position, diff.position),
           rotation: layer.rotation + diff.rotation,
         };
-      })
+      });
     };
 
     useEffect(() => {

--- a/frontend/src/components/editor/layers/layer.tsx
+++ b/frontend/src/components/editor/layers/layer.tsx
@@ -9,8 +9,9 @@ import {
 } from "react-konva";
 import Konva from "konva";
 
-import { v2Sub } from "@/models/editor/layers/layerUtils";
-import { LayerProps } from "@/models/editor/layers/layerProps";
+import { v2Add, v2Sub } from "@/models/editor/layers/layerUtils";
+import { LayerProps, TransformDiff } from "@/models/editor/layers/layerProps";
+import { useEditorContext } from "../editorContext";
 
 export const LayerComponent = forwardRef<Konva.Group, LayerProps>(
   (props, groupRef) => {
@@ -23,10 +24,22 @@ export const LayerComponent = forwardRef<Konva.Group, LayerProps>(
       isVisible,
       isSelected,
       lines,
-      setIsTransforming,
-      transformSelectedLayers,
     }: Partial<LayerProps> = props;
+
+    const { editSelectedLayers, isTransforming } = useEditorContext();
+
     const transformerRef = useRef<Konva.Transformer>(null);
+
+    const transformSelectedLayers = (diff: TransformDiff) => {
+      editSelectedLayers(layer => {
+        return {
+          ...layer,
+          scale: v2Add(layer.scale, diff.scale),
+          position: v2Add(layer.position, diff.position),
+          rotation: layer.rotation + diff.rotation,
+        };
+      })
+    };
 
     useEffect(() => {
       if (isSelected && groupRef) {
@@ -54,7 +67,7 @@ export const LayerComponent = forwardRef<Konva.Group, LayerProps>(
         {isSelected && isVisible && (
           <KonvaTransformer
             onTransformStart={() => {
-              setIsTransforming(true);
+              isTransforming.current = true;
             }}
             onTransformEnd={handleTransformEnd}
             ref={transformerRef}

--- a/frontend/src/components/editor/tools/move.tsx
+++ b/frontend/src/components/editor/tools/move.tsx
@@ -1,7 +1,9 @@
 import { Tool } from "@/models/editor/tools/tool";
 import { ToolConfiguration } from "@/models/editor/tools/toolConfiguration";
 import { ToolConfigurationProps } from "@/models/editor/tools/toolConfigurationProps";
+import { CANVAS_DRAG_MOUSE_BUTTON, KonvaMouseEvent, PRIMARY_MOUSE_BUTTON } from "@/models/editor/utils/events";
 import OpenWithRoundedIcon from "@mui/icons-material/OpenWithRounded";
+import { useEditorContext } from "../editorContext";
 
 export type MoveToolConfiguration = ToolConfiguration;
 
@@ -22,6 +24,30 @@ export const MoveToolConfigurationComponent = ({
     </div>
   );
 };
+
+const { editSelectedLayers } = useEditorContext();
+
+const handleMouseDown = (e: KonvaMouseEvent) => {
+  e.evt.preventDefault();
+  if (e.evt.button == PRIMARY_MOUSE_BUTTON) {
+    setLayerDragStartPosition(getCanvasPointerPosition());
+    isHoldingPrimary.current = true;
+
+    editSelectedLayers(layer => {
+      if (!layer.isSelected) {
+        return layer;
+      }
+      return {
+        ...layer,
+        positionBeforeDrag: {
+          x: layer.position.x,
+          y: layer.position.y,
+        },
+      };
+    }, true)
+  }
+};
+
 
 export const MOVE_TOOL: Tool<MoveToolConfiguration> = {
   name: "Move",

--- a/frontend/src/components/editor/tools/move.tsx
+++ b/frontend/src/components/editor/tools/move.tsx
@@ -1,7 +1,7 @@
 import { Tool } from "@/models/editor/tools/tool";
 import { ToolConfiguration } from "@/models/editor/tools/toolConfiguration";
 import { ToolConfigurationProps } from "@/models/editor/tools/toolConfigurationProps";
-import { CANVAS_DRAG_MOUSE_BUTTON, KonvaMouseEvent, MOUSE_DOWN, PRIMARY_MOUSE_BUTTON } from "@/models/editor/utils/events";
+import { KonvaMouseEvent } from "@/models/editor/utils/events";
 import OpenWithRoundedIcon from "@mui/icons-material/OpenWithRounded";
 import { useEditorContext } from "../editorContext";
 import { useState, useCallback, useRef } from "react";
@@ -18,7 +18,17 @@ export const MoveToolConfigurationComponent = ({
   console.log(configuration);
   console.log(setConfiguration);
 
-  const { isHoldingPrimary, isTransforming, editSelectedLayers, setToolEventHandlers, getCanvasPointerPosition, commitVirtualLayers, setVirtualLayers, stageRef, updateLayer } = useEditorContext();
+  const {
+    isHoldingPrimary,
+    isTransforming,
+    editSelectedLayers,
+    setToolEventHandlers,
+    getCanvasPointerPosition,
+    commitVirtualLayers,
+    setVirtualLayers,
+    stageRef,
+    updateLayer,
+  } = useEditorContext();
 
   const [layerDragStartPosition, setLayerDragStartPosition] =
     useState<Vector2d>({
@@ -34,12 +44,11 @@ export const MoveToolConfigurationComponent = ({
   const getLayerDragPositionDiff = useCallback(() => {
     const canvasPosition = getCanvasPointerPosition();
     return v2Sub(canvasPosition, layerDragStartPosition);
-
   }, [getCanvasPointerPosition, layerDragStartPosition]);
 
   // Click handler for stage handling layer selection
-  const handleLayerSelection = (e: KonvaMouseEvent) => {
-    if (!e.evt.ctrlKey) {
+  const handleLayerSelection = (e: KonvaMouseEvent | undefined) => {
+    if (!e?.evt.ctrlKey) {
       // Start by de-selecting all layers
       setVirtualLayers((prev) => {
         return prev.map((layer) => {
@@ -76,23 +85,22 @@ export const MoveToolConfigurationComponent = ({
     }
   };
 
-
   const handleMouseDown = () => {
-      setLayerDragStartPosition(getCanvasPointerPosition());
-      isHoldingPrimary.current = true;
+    setLayerDragStartPosition(getCanvasPointerPosition());
+    isHoldingPrimary.current = true;
 
-      editSelectedLayers(layer => {
-        if (!layer.isSelected) {
-          return layer;
-        }
-        return {
-          ...layer,
-          positionBeforeDrag: {
-            x: layer.position.x,
-            y: layer.position.y,
-          },
-        };
-      }, true)
+    editSelectedLayers((layer) => {
+      if (!layer.isSelected) {
+        return layer;
+      }
+      return {
+        ...layer,
+        positionBeforeDrag: {
+          x: layer.position.x,
+          y: layer.position.y,
+        },
+      };
+    }, true);
   };
 
   const handleMouseMove = () => {
@@ -107,19 +115,18 @@ export const MoveToolConfigurationComponent = ({
 
       isDraggingLayers.current = true;
 
-      editSelectedLayers(layer => {
+      editSelectedLayers((layer) => {
         return {
           ...layer,
           position: v2Add(layer.positionBeforeDrag, positionDiff),
         };
-      }, true)
+      }, true);
 
       return;
     }
-
   };
 
-  const handleMouseUp = (e: KonvaMouseEvent) => {
+  const handleMouseUp = (e: KonvaMouseEvent | undefined) => {
     if (isTransforming.current) {
       isTransforming.current = false;
       return;
@@ -128,16 +135,15 @@ export const MoveToolConfigurationComponent = ({
     if (isDraggingLayers.current) {
       commitVirtualLayers();
       isDraggingLayers.current = false;
-    }
-    else {
+    } else {
       return handleLayerSelection(e);
     }
   };
 
   setToolEventHandlers({
-     mouseDown: handleMouseDown,
-     mouseMove: handleMouseMove,
-     mouseUp: handleMouseUp,
+    mouseDown: handleMouseDown,
+    mouseMove: handleMouseMove,
+    mouseUp: handleMouseUp,
   });
 
   return (

--- a/frontend/src/components/editor/tools/move.tsx
+++ b/frontend/src/components/editor/tools/move.tsx
@@ -1,9 +1,12 @@
 import { Tool } from "@/models/editor/tools/tool";
 import { ToolConfiguration } from "@/models/editor/tools/toolConfiguration";
 import { ToolConfigurationProps } from "@/models/editor/tools/toolConfigurationProps";
-import { CANVAS_DRAG_MOUSE_BUTTON, KonvaMouseEvent, PRIMARY_MOUSE_BUTTON } from "@/models/editor/utils/events";
+import { CANVAS_DRAG_MOUSE_BUTTON, KonvaMouseEvent, MOUSE_DOWN, PRIMARY_MOUSE_BUTTON } from "@/models/editor/utils/events";
 import OpenWithRoundedIcon from "@mui/icons-material/OpenWithRounded";
 import { useEditorContext } from "../editorContext";
+import { useState, useCallback, useRef } from "react";
+import { Vector2d } from "konva/lib/types";
+import { v2Add, v2Sub } from "@/models/editor/layers/layerUtils";
 
 export type MoveToolConfiguration = ToolConfiguration;
 
@@ -15,6 +18,128 @@ export const MoveToolConfigurationComponent = ({
   console.log(configuration);
   console.log(setConfiguration);
 
+  const { isHoldingPrimary, isTransforming, editSelectedLayers, setToolEventHandlers, getCanvasPointerPosition, commitVirtualLayers, setVirtualLayers, stageRef, updateLayer } = useEditorContext();
+
+  const [layerDragStartPosition, setLayerDragStartPosition] =
+    useState<Vector2d>({
+      x: 0,
+      y: 0,
+    });
+
+  const isDraggingLayers = useRef(false);
+
+  // Determine whether or not the mouse is dragging across the canvas. The
+  // mouse needs to move past a certain threshold before the action is
+  // considered a drag and not a click.
+  const getLayerDragPositionDiff = useCallback(() => {
+    const canvasPosition = getCanvasPointerPosition();
+    return v2Sub(canvasPosition, layerDragStartPosition);
+
+  }, [getCanvasPointerPosition, layerDragStartPosition]);
+
+  // Click handler for stage handling layer selection
+  const handleLayerSelection = (e: KonvaMouseEvent) => {
+    if (!e.evt.ctrlKey) {
+      // Start by de-selecting all layers
+      setVirtualLayers((prev) => {
+        return prev.map((layer) => {
+          return {
+            ...layer,
+            isSelected: false,
+          };
+        });
+      });
+    }
+
+    const pointer = stageRef.current?.getPointerPosition();
+    if (!pointer) {
+      return;
+    }
+
+    const target = stageRef.current?.getIntersection(pointer);
+
+    if (target) {
+      const layerId = target.parent?.id();
+      if (!layerId) {
+        return;
+      }
+      updateLayer(
+        layerId,
+        (prev) => {
+          return {
+            ...prev,
+            isSelected: true,
+          };
+        },
+        true,
+      );
+    }
+  };
+
+
+  const handleMouseDown = () => {
+      setLayerDragStartPosition(getCanvasPointerPosition());
+      isHoldingPrimary.current = true;
+
+      editSelectedLayers(layer => {
+        if (!layer.isSelected) {
+          return layer;
+        }
+        return {
+          ...layer,
+          positionBeforeDrag: {
+            x: layer.position.x,
+            y: layer.position.y,
+          },
+        };
+      }, true)
+  };
+
+  const handleMouseMove = () => {
+    if (isHoldingPrimary.current) {
+      const positionDiff = getLayerDragPositionDiff();
+
+      // Not dragging
+      // FIXME: Maybe update threshold?
+      if (Math.hypot(positionDiff.x, positionDiff.y) < 2) {
+        return;
+      }
+
+      isDraggingLayers.current = true;
+
+      editSelectedLayers(layer => {
+        return {
+          ...layer,
+          position: v2Add(layer.positionBeforeDrag, positionDiff),
+        };
+      }, true)
+
+      return;
+    }
+
+  };
+
+  const handleMouseUp = (e: KonvaMouseEvent) => {
+    if (isTransforming.current) {
+      isTransforming.current = false;
+      return;
+    }
+
+    if (isDraggingLayers.current) {
+      commitVirtualLayers();
+      isDraggingLayers.current = false;
+    }
+    else {
+      return handleLayerSelection(e);
+    }
+  };
+
+  setToolEventHandlers({
+     mouseDown: handleMouseDown,
+     mouseMove: handleMouseMove,
+     mouseUp: handleMouseUp,
+  });
+
   return (
     <div>
       <p className="text-violet-50">
@@ -24,30 +149,6 @@ export const MoveToolConfigurationComponent = ({
     </div>
   );
 };
-
-const { editSelectedLayers } = useEditorContext();
-
-const handleMouseDown = (e: KonvaMouseEvent) => {
-  e.evt.preventDefault();
-  if (e.evt.button == PRIMARY_MOUSE_BUTTON) {
-    setLayerDragStartPosition(getCanvasPointerPosition());
-    isHoldingPrimary.current = true;
-
-    editSelectedLayers(layer => {
-      if (!layer.isSelected) {
-        return layer;
-      }
-      return {
-        ...layer,
-        positionBeforeDrag: {
-          x: layer.position.x,
-          y: layer.position.y,
-        },
-      };
-    }, true)
-  }
-};
-
 
 export const MOVE_TOOL: Tool<MoveToolConfiguration> = {
   name: "Move",

--- a/frontend/src/components/editor/tools/paint.tsx
+++ b/frontend/src/components/editor/tools/paint.tsx
@@ -5,6 +5,10 @@ import { Tool } from "@/models/editor/tools/tool";
 import { ToolConfiguration } from "@/models/editor/tools/toolConfiguration";
 import { ToolConfigurationProps } from "@/models/editor/tools/toolConfigurationProps";
 import BrushRoundedIcon from "@mui/icons-material/BrushRounded";
+import { useRef } from "react";
+import { useEditorContext } from "../editorContext";
+import { v2Sub } from "@/models/editor/layers/layerUtils";
+import { Layer } from "@/models/editor/layers/layer";
 
 export interface PaintToolConfiguration extends ToolConfiguration {
   radius: number;
@@ -15,24 +19,70 @@ export const PaintToolConfigurationComponent = ({
   configuration,
   setConfiguration,
 }: ToolConfigurationProps<PaintToolConfiguration>) => {
-  // const handleDrawStart = (e: KonvaMouseEvent) => {
-  //   isDrawing.current = true;
+  const isDrawing = useRef(false);
+  const {
+    editSelectedLayers,
+    getCanvasPointerPosition,
+    setToolEventHandlers,
+    commitVirtualLayers,
+  } = useEditorContext();
 
-  //   editSelectedLayers(layer => {
-  //     const pointPosition = v2Sub(getCanvasPointerPosition(), layer.position);
-  //     return {
-  //       ...layer,
-  //       lines: layer.lines.concat([
-  //         {
-  //           points: [pointPosition.x, pointPosition.y],
-  //           color: "",
-  //           width: 3,
-  //           tool: null,
-  //         }
-  //       ])
-  //     };
-  //   }, true);
-  // };
+  const getLayerCursorPosition = (layer: Layer) => {
+    return v2Sub(getCanvasPointerPosition(), layer.position);
+  };
+
+  const handleMouseDown = () => {
+    isDrawing.current = true;
+
+    editSelectedLayers((layer) => {
+      const pointPosition = getLayerCursorPosition(layer);
+      return {
+        ...layer,
+        lines: layer.lines.concat([
+          {
+            points: [pointPosition.x, pointPosition.y],
+            color: configuration.color,
+            width: configuration.radius,
+            tool: null,
+          },
+        ]),
+      };
+    }, true);
+  };
+
+  const handleMouseMove = () => {
+    if (!isDrawing.current) {
+      return;
+    }
+
+    // TODO: Restrict drawing to inside the layer
+    editSelectedLayers((layer) => {
+      console.log("layer", layer);
+      const pointPosition = getLayerCursorPosition(layer);
+      const lines = layer.lines.slice();
+      const currentLine = lines[lines.length - 1];
+      currentLine.points = currentLine.points.concat([
+        pointPosition.x,
+        pointPosition.y,
+      ]);
+
+      layer.lines = lines;
+      return layer;
+    }, true);
+  };
+
+  const handleMouseUp = () => {
+    if (isDrawing.current) {
+      isDrawing.current = false;
+      commitVirtualLayers();
+    }
+  };
+
+  setToolEventHandlers({
+    mouseDown: handleMouseDown,
+    mouseMove: handleMouseMove,
+    mouseUp: handleMouseUp,
+  });
 
   return (
     <div>

--- a/frontend/src/components/editor/tools/paint.tsx
+++ b/frontend/src/components/editor/tools/paint.tsx
@@ -15,25 +15,24 @@ export const PaintToolConfigurationComponent = ({
   configuration,
   setConfiguration,
 }: ToolConfigurationProps<PaintToolConfiguration>) => {
+  // const handleDrawStart = (e: KonvaMouseEvent) => {
+  //   isDrawing.current = true;
 
-  const handleDrawStart = (e: KonvaMouseEvent) => {
-    isDrawing.current = true;
-
-    editSelectedLayers(layer => {
-      const pointPosition = v2Sub(getCanvasPointerPosition(), layer.position);
-      return {
-        ...layer,
-        lines: layer.lines.concat([
-          {
-            points: [pointPosition.x, pointPosition.y],
-            color: "",
-            width: 3,
-            tool: null,
-          }
-        ])
-      };
-    }, true);
-  };
+  //   editSelectedLayers(layer => {
+  //     const pointPosition = v2Sub(getCanvasPointerPosition(), layer.position);
+  //     return {
+  //       ...layer,
+  //       lines: layer.lines.concat([
+  //         {
+  //           points: [pointPosition.x, pointPosition.y],
+  //           color: "",
+  //           width: 3,
+  //           tool: null,
+  //         }
+  //       ])
+  //     };
+  //   }, true);
+  // };
 
   return (
     <div>

--- a/frontend/src/components/editor/tools/paint.tsx
+++ b/frontend/src/components/editor/tools/paint.tsx
@@ -15,6 +15,26 @@ export const PaintToolConfigurationComponent = ({
   configuration,
   setConfiguration,
 }: ToolConfigurationProps<PaintToolConfiguration>) => {
+
+  const handleDrawStart = (e: KonvaMouseEvent) => {
+    isDrawing.current = true;
+
+    editSelectedLayers(layer => {
+      const pointPosition = v2Sub(getCanvasPointerPosition(), layer.position);
+      return {
+        ...layer,
+        lines: layer.lines.concat([
+          {
+            points: [pointPosition.x, pointPosition.y],
+            color: "",
+            width: 3,
+            tool: null,
+          }
+        ])
+      };
+    }, true);
+  };
+
   return (
     <div>
       <p className="text-violet-50">

--- a/frontend/src/components/editor/tools/paint.tsx
+++ b/frontend/src/components/editor/tools/paint.tsx
@@ -25,6 +25,7 @@ export const PaintToolConfigurationComponent = ({
     getCanvasPointerPosition,
     setToolEventHandlers,
     commitVirtualLayers,
+    layers,
   } = useEditorContext();
 
   const getLayerCursorPosition = (layer: Layer) => {
@@ -32,6 +33,19 @@ export const PaintToolConfigurationComponent = ({
   };
 
   const handleMouseDown = () => {
+    // If no layer is selected, don't set isDrawing in order to not update the history
+    let hasSelectedLayer = false;
+    for (const layer of layers) {
+      if (layer.isSelected) {
+        hasSelectedLayer = true;
+        break;
+      }
+    }
+
+    if (!hasSelectedLayer) {
+      return;
+    }
+
     isDrawing.current = true;
 
     editSelectedLayers((layer) => {
@@ -57,7 +71,6 @@ export const PaintToolConfigurationComponent = ({
 
     // TODO: Restrict drawing to inside the layer
     editSelectedLayers((layer) => {
-      console.log("layer", layer);
       const pointPosition = getLayerCursorPosition(layer);
       const lines = layer.lines.slice();
       const currentLine = lines[lines.length - 1];

--- a/frontend/src/components/editor/undoRedo.tsx
+++ b/frontend/src/components/editor/undoRedo.tsx
@@ -1,6 +1,8 @@
 import { useState, useCallback } from "react";
 import { CircularBuffer } from "@/models/editor/utils/CircularBuffer";
 
+export type VirtualStateSetter<T> = (newState: T | ((prev: T) => T)) => void;
+
 /// Hook to store state with undo / redo capabilities.
 /// It has the ability to group multiple smaller modifications into one.
 /// capacity sets the maximum number of states to keep in memory.

--- a/frontend/src/models/editor/layers/layerProps.ts
+++ b/frontend/src/models/editor/layers/layerProps.ts
@@ -18,6 +18,4 @@ export interface LayerProps {
   isSelected: boolean;
   lines: Line[];
   updateLayer: (callback: LayerUpdateCallback, virtual: boolean) => void;
-  setIsTransforming: (val: boolean) => void;
-  transformSelectedLayers: (diff: TransformDiff) => void;
 }

--- a/frontend/src/models/editor/tools/tool.ts
+++ b/frontend/src/models/editor/tools/tool.ts
@@ -9,7 +9,7 @@ export interface Tool<T extends ToolConfiguration> {
   initialConfiguration: T;
   configurationComponent: React.FC<ToolConfigurationProps<T>>;
 
-  handleMouseDown?: (event: KonvaMouseEvent) => void,
-  handleMouseMove?: (event: KonvaMouseEvent) => void,
-  handleMouseUp?: (event: KonvaMouseEvent) => void,
+  handleMouseDown?: (event: KonvaMouseEvent) => void;
+  handleMouseMove?: (event: KonvaMouseEvent) => void;
+  handleMouseUp?: (event: KonvaMouseEvent) => void;
 }

--- a/frontend/src/models/editor/tools/tool.ts
+++ b/frontend/src/models/editor/tools/tool.ts
@@ -1,10 +1,15 @@
 import { ReactNode } from "react";
 import { ToolConfiguration } from "./toolConfiguration";
 import { ToolConfigurationProps } from "./toolConfigurationProps";
+import { KonvaMouseEvent } from "../utils/events";
 
 export interface Tool<T extends ToolConfiguration> {
   name: string;
   icon: ReactNode;
   initialConfiguration: T;
   configurationComponent: React.FC<ToolConfigurationProps<T>>;
+
+  handleMouseDown?: (event: KonvaMouseEvent) => void,
+  handleMouseMove?: (event: KonvaMouseEvent) => void,
+  handleMouseUp?: (event: KonvaMouseEvent) => void,
 }

--- a/frontend/src/models/editor/utils/events.ts
+++ b/frontend/src/models/editor/utils/events.ts
@@ -9,8 +9,8 @@ export const CANVAS_DRAG_MOUSE_BUTTON = 1;
 export type KonvaMouseEvent = KonvaEventObject.KonvaEventObject<MouseEvent>;
 export type KonvaScrollEvent = KonvaEventObject.KonvaEventObject<WheelEvent>;
 
-export const MOUSE_DOWN = "mouseDown"
-export const MOUSE_MOVE = "mouseMove"
-export const MOUSE_UP = "mouseUp"
+export const MOUSE_DOWN = "mouseDown";
+export const MOUSE_MOVE = "mouseMove";
+export const MOUSE_UP = "mouseUp";
 
 export type EventType = typeof MOUSE_DOWN | typeof MOUSE_MOVE | typeof MOUSE_UP;

--- a/frontend/src/models/editor/utils/events.ts
+++ b/frontend/src/models/editor/utils/events.ts
@@ -9,4 +9,8 @@ export const CANVAS_DRAG_MOUSE_BUTTON = 1;
 export type KonvaMouseEvent = KonvaEventObject.KonvaEventObject<MouseEvent>;
 export type KonvaScrollEvent = KonvaEventObject.KonvaEventObject<WheelEvent>;
 
+export const MOUSE_DOWN = "mouseDown"
+export const MOUSE_MOVE = "mouseMove"
+export const MOUSE_UP = "mouseUp"
 
+export type EventType = typeof MOUSE_DOWN | typeof MOUSE_MOVE | typeof MOUSE_UP;

--- a/frontend/src/models/editor/utils/events.ts
+++ b/frontend/src/models/editor/utils/events.ts
@@ -1,0 +1,12 @@
+import KonvaEventObject from "konva";
+
+// Left click
+export const PRIMARY_MOUSE_BUTTON = 0;
+
+// Middle click
+export const CANVAS_DRAG_MOUSE_BUTTON = 1;
+
+export type KonvaMouseEvent = KonvaEventObject.KonvaEventObject<MouseEvent>;
+export type KonvaScrollEvent = KonvaEventObject.KonvaEventObject<WheelEvent>;
+
+


### PR DESCRIPTION
## Linked issue

Resolves: #86 

## Summary

This integrates the paint tool implementation from my PoC. 

In order to avoid technical debt, I decided to do a pretty big refactor. The goal was to move the tools' logic from the `Canvas` component to the corresponding tools configuration components. To do this, I created an `EditorContext` which gives access to the layer edition to all the child components. Now, the `Canvas` component is only responsible for zooming / panning and simply delegates the other events to the selected tool. 

